### PR TITLE
Ignore directories matching *_test(s)

### DIFF
--- a/dodgy/run.py
+++ b/dodgy/run.py
@@ -10,6 +10,8 @@ IGNORE_PATHS = [re.compile(patt % {'sep': re.escape(os.path.sep)}) for patt in (
     r'(^|%(sep)s)\.[^\.]',   # ignores any files or directories starting with '.'
     r'^tests?%(sep)s?',
     r'%(sep)stests?(%(sep)s|$)',
+    # Ignore foo_test(s)/.
+    r'_tests?(%(sep)s|$)',
 )]
 
 


### PR DESCRIPTION
This skips checks in a dir like pytest_django_test for the pytest_django
package.