### PR TITLE
Add CLI and fix edge case with gzipped text files

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,9 +25,9 @@ jobs:
       run: |
         pip install flake8
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=tests/testdata/ --max-line-length=120
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=tests/testdata/ --max-line-length=120
     - name: Test with nose
       run: |
         pip install nose coverage coveralls

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,10 +28,11 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+    - name: Test with nose
       run: |
-        pip install pytest
-        pytest
+        pip install nose coverage coveralls
+        pip install --editable .
+        nosetests dodgy -s --with-coverage --cover-inclusive --cover-package=dodgy
     - name: Create package
       run: |
         pip install setuptools wheel

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -41,5 +41,5 @@ jobs:
       run: |
         pip install twine
         # Needs TWINE_USERNAME and TWINE_PASSWORD set as github secrets:
-        twine upload dist/*.whl || echo 'Unable to upload to PyPI [code=$?]'
+        twine upload dist/*.whl || echo 'Unable to upload to PyPI' 1>&2
       if: endsWith(github.ref, 'master')

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -42,4 +42,4 @@ jobs:
         pip install twine
         # Needs TWINE_USERNAME and TWINE_PASSWORD set as github secrets:
         twine upload dist/*.whl || echo 'Unable to upload to PyPI [code=$?]'
-      if: github.ref == 'master'
+      if: github.ref == 'refs/head/master'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -42,4 +42,4 @@ jobs:
         pip install twine
         # Needs TWINE_USERNAME and TWINE_PASSWORD set as github secrets:
         twine upload dist/*.whl || echo 'Unable to upload to PyPI [code=$?]'
-      if: github.ref == 'refs/head/master'
+      if: endsWith(github.ref, 'master')

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        # pip install -r requirements.txt
     - name: Lint with flake8
       run: |
         pip install flake8
@@ -32,3 +32,13 @@ jobs:
       run: |
         pip install pytest
         pytest
+    - name: Create package
+      run: |
+        pip install setuptools wheel
+        python setup.py bdist build bdist_wheel
+    - name: Upload package
+      run: |
+        pip install twine
+        # Needs TWINE_USERNAME and TWINE_PASSWORD set as github secrets:
+        twine upload dist/*.whl || echo 'Unable to upload to PyPI [code=$?]'
+      if: github.ref == 'master'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - "pip install nose coverage coveralls"
   - "pip install --editable ."

--- a/bin/dodgy
+++ b/bin/dodgy
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 
 import dodgy.run
-dodgy.run.run()
+dodgy.run.main()

--- a/dodgy/__main__.py
+++ b/dodgy/__main__.py
@@ -1,0 +1,3 @@
+import dodgy.run
+
+dodgy.run.run()

--- a/dodgy/__main__.py
+++ b/dodgy/__main__.py
@@ -1,3 +1,3 @@
 import dodgy.run
 
-dodgy.run.run()
+dodgy.run.main()

--- a/dodgy/__pkginfo__.py
+++ b/dodgy/__pkginfo__.py
@@ -1,5 +1,5 @@
 
-VERSION = (0, 1, 9)
+VERSION = (0, 1, 10)
 
 
 def get_version():

--- a/dodgy/checks.py
+++ b/dodgy/checks.py
@@ -1,5 +1,8 @@
 import re
 import codecs
+import gzip
+
+from functools import partial
 
 
 STRING_VALS = (
@@ -68,7 +71,13 @@ def check_line(line, check_list):
 
 
 def check_file(filepath):
-    with codecs.open(filepath, 'r', 'utf-8') as to_check:
+    if filepath.endswith('.gz'):
+        # this file looks like it is using gzip compression
+        fopen = partial(gzip.open, mode='rt')
+    else:
+        # otherwise treat as standard text file
+        fopen = partial(codecs.open, mode='r')
+    with fopen(filepath, encoding='utf-8') as to_check:
         return check_file_contents(to_check.read())
 
 
@@ -77,6 +86,7 @@ def check_file_contents(file_contents):
 
     for line_number0, line in enumerate(file_contents.split('\n')):
         for check_list in (STRING_VALS, LINE_VALS, VAR_NAMES):
-            messages += [(line_number0 + 1, key, msg) for key, msg in check_line(line, check_list)]
+            messages += [(line_number0 + 1, key, msg)
+                         for key, msg in check_line(line, check_list)]
 
     return messages

--- a/dodgy/checks.py
+++ b/dodgy/checks.py
@@ -31,7 +31,7 @@ LINE_VALS = (
     (
         'ssh_rsa_public_key',
         'Possible SSH public key',
-        re.compile('^ssh-rsa\s+AAAA[0-9A-Za-z+/]+[=]{0,3}\s*([^@]+@[^@]+)?$')
+        re.compile(r'^ssh-rsa\s+AAAA[0-9A-Za-z+/]+[=]{0,3}\s*([^@]+@[^@]+)?$')
     ),
 )
 
@@ -77,6 +77,6 @@ def check_file_contents(file_contents):
 
     for line_number0, line in enumerate(file_contents.split('\n')):
         for check_list in (STRING_VALS, LINE_VALS, VAR_NAMES):
-            messages += [(line_number0+1, key, msg) for key, msg in check_line(line, check_list)]
+            messages += [(line_number0 + 1, key, msg) for key, msg in check_line(line, check_list)]
 
     return messages

--- a/dodgy/run.py
+++ b/dodgy/run.py
@@ -9,7 +9,8 @@ from argparse import ArgumentParser
 from dodgy.checks import check_file
 
 
-IGNORE_PATHS = [re.compile(patt % {'sep': re.escape(os.path.sep)}) for patt in (
+IGNORE_PATHS = [re.compile(patt % {'sep': re.escape(os.path.sep)})
+                for patt in (
     r'(^|%(sep)s)\.[^\.]',   # ignores any files or directories starting with '.'
     r'^tests?%(sep)s?',
     r'%(sep)stests?(%(sep)s|$)',

--- a/dodgy/run.py
+++ b/dodgy/run.py
@@ -3,6 +3,9 @@ import re
 import os
 import mimetypes
 import json
+
+from argparse import ArgumentParser
+
 from dodgy.checks import check_file
 
 
@@ -41,22 +44,39 @@ def run_checks(directory, ignore_paths=None):
         if mimetype[0] is None or not mimetype[0].startswith('text/'):
             continue
 
-        for msg_parts in check_file(filepath):
-            warnings.append({
-                'path': relpath,
-                'line': msg_parts[0],
-                'code': msg_parts[1],
-                'message': msg_parts[2]
-            })
+        try:
+            for msg_parts in check_file(filepath):
+                warnings.append({
+                    'path': relpath,
+                    'line': msg_parts[0],
+                    'code': msg_parts[1],
+                    'message': msg_parts[2]
+                })
+        except UnicodeDecodeError as err:
+            # This is a file which cannot be opened using codecs with UTF-8
+            print('Unable to read {!r}: {}'.format(filepath, err))
 
     return warnings
 
 
-def run():
-    warnings = run_checks(os.getcwd())
+def run(ignore_paths=None):
+    warnings = run_checks(os.getcwd(), ignore_paths=ignore_paths)
     output = json.dumps({'warnings': warnings}, indent=2)
     sys.stdout.write(output + '\n')
 
 
+def main(argv=sys.argv):
+    desc = ('A very basic tool to run against your codebase to search for "dodgy" looking values. '
+            'It is a series of simple regular expressions designed to detect things such as '
+            'accidental SCM diff checkins, or passwords/secret keys hardcoded into files.')
+    parser = ArgumentParser('dodgy', description=desc)
+    parser.add_argument('--ignore-paths', '-i', nargs='+',
+                        type=str, dest='ignore', default=None,
+                        metavar='IGNORE_PATH', help='Paths to ignore')
+    args, _ = parser.parse_known_args(argv)
+
+    run(ignore_paths=args.ignore)
+
+
 if __name__ == '__main__':
-    run()
+    main()


### PR DESCRIPTION
This PR aims to address #15 (Unicode issue with try/except workaround)  and #5 (adds command line interface with ability to specify ignore paths and enables `dodgy --help`)

There is also a version bump.

Note this PR also makes use of GitHub actions (see `.github/workflows/pythonpackage.yml`) and could be combined with GitHub's secrets to add `$TWINE_USERNAME` and `$TWINE_PASSWORD` to enable automatic uploading of dodgy to PyPI.