### PR TITLE
Make bin/dogdy return an exit_code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - "pip install nose coverage coveralls"
   - "pip install --editable ."
-script:
-  nosetests dodgy -s --with-coverage --cover-inclusive --cover-package=dodgy
-after_success:
-  coveralls
+script: nosetests dodgy -s --with-coverage --cover-inclusive --cover-package=dodgy
+after_success: coveralls

--- a/bin/dodgy
+++ b/bin/dodgy
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
 
+import sys
+import dodgy.configuration
 import dodgy.run
-dodgy.run.run()
+
+args = dodgy.configuration.get_options(sys.argv[1:])
+result = dodgy.run.run()
+
+if args.zero_exit:
+    sys.exit(result)

--- a/dodgy/configuration.py
+++ b/dodgy/configuration.py
@@ -1,0 +1,12 @@
+import argparse
+
+
+def get_options(argv=None):
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    parser.add_argument(
+        "--zero-exit",
+        help="Dodgy will exit with a code of 1 if problems are found",
+        action="store_true"
+    )
+
+    return parser.parse_args(argv)

--- a/dodgy/run.py
+++ b/dodgy/run.py
@@ -54,8 +54,13 @@ def run_checks(directory, ignore_paths=None):
 
 def run():
     warnings = run_checks(os.getcwd())
-    output = json.dumps({'warnings': warnings}, indent=2)
-    sys.stdout.write(output + '\n')
+
+    if (warnings):
+        output = json.dumps({'warnings': warnings}, indent=2)
+        sys.stdout.write(output + '\n')
+        return 1
+    
+    return 0
 
 
 if __name__ == '__main__':

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+from dodgy.configuration import get_options
+
+
+class TestGetOptions(TestCase):
+
+    def test_zero_exit_disabled_by_default(self):
+        args = get_options([])
+        self.assertFalse(args.zero_exit)
+
+    def test_zero_exit_enabled(self):
+        args = get_options(['--zero-exit'])
+        self.assertTrue(args.zero_exit)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,16 @@
+from unittest import TestCase
+from mock import patch
+from dodgy.run import run
+
+
+class TestRun(TestCase):
+
+    @patch('dodgy.run.run_checks')
+    def test_return_zero_for_success(self, run_checks_mock):
+        run_checks_mock.return_value = []
+        self.assertEqual(run(), 0)
+
+    @patch('dodgy.run.run_checks')
+    def test_return_1_for_warnings(self, run_checks_mock):
+        run_checks_mock.return_value = ['should-be-warning']
+        self.assertEqual(run(), 1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
-envlist = py26,py27,py33,py34,py35
+envlist = py26,py27,py33,py34,py35,py36
 
 [testenv]
-deps=nose
+deps=
+    nose
+    mock
 commands=nosetests -s
 


### PR DESCRIPTION
By adding the possibility of returning an `exit_code`, we can successfully use `dodgy` integrated with other tools (like `pre-commit`).