### PR TITLE
include license in pypi package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include bin/dodgy
+include LICENSE


### PR DESCRIPTION
This way downstream packagers can honor the license.

xref: https://github.com/conda-forge/dodgy-feedstock/pull/3