### PR TITLE
Remove dodgy mention from _short_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from dodgy import __pkginfo__
 
 _packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 
-_short_description = "Dodgy: Searches for dodgy looking lines in Python code"
+_short_description = "Searches for dodgy looking lines in Python code"
 
 _install_requires = []
 


### PR DESCRIPTION
The package name shouldn't be in the description.